### PR TITLE
Add Streamlit interface for geological modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ We welcome contributions to `geo-lm`\! If you have ideas for improvements, new f
 ## Notes
 
 This package was originally called `hutton-lm`, but was renamed to `geo-lm` last minute!
+
+## Streamlit App
+
+Launch the web demo with:
+
+```bash
+streamlit run streamlit_app.py --server.address 0.0.0.0
+```
+
+Other users on your local network can then open `http://<your-ip>:8501` to access the interface.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ streamlit run streamlit_app.py --server.address 0.0.0.0
 ```
 
 Other users on your local network can then open `http://<your-ip>:8501` to access the interface.
+

--- a/hutton_lm/model_builder.py
+++ b/hutton_lm/model_builder.py
@@ -278,4 +278,26 @@ def compute_and_plot_model(geo_model: gp.data.GeoModel):
     print("Plot window should be open.")
 
 
+def compute_model_to_html(geo_model: gp.data.GeoModel, html_path: str) -> str:
+    """Computes the model and exports an interactive HTML visualization."""
+    import pyvista as pv
+    import nest_asyncio
+
+    nest_asyncio.apply()
+    pv.start_xvfb()
+
+    gp.compute_model(gempy_model=geo_model)
+    vista = gpv.plot_3d(
+        model=geo_model,
+        show_surfaces=True,
+        show_data=True,
+        image=False,
+        show_topography=True,
+        kwargs_plot_structured_grid={"opacity": 0.2},
+        show=False,
+    )
+    vista.p.export_html(html_path)
+    return html_path
+
+
 # ---------------------------------------

--- a/hutton_lm/pdf_parser.py
+++ b/hutton_lm/pdf_parser.py
@@ -1,7 +1,8 @@
 import os
+import tempfile
 import PyPDF2
 from tqdm import tqdm
-from typing import Optional
+from typing import Optional, BinaryIO
 
 
 # https://github.com/meta-llama/llama-cookbook/blob/main/end-to-end-use-cases/NotebookLlama/Step-1%20PDF-Pre-Processing-Logic.ipynb
@@ -74,3 +75,19 @@ def extract_images_from_pdf(file_path: str, output_dir: str) -> None:
     # Placeholder: In a real implementation, this would extract images
     # and save them to the output_dir, potentially returning a list of image paths.
     return None
+
+
+def extract_text(uploaded_file: BinaryIO) -> Optional[str]:
+    """Extracts text from an uploaded PDF file object."""
+    if uploaded_file is None:
+        return None
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+            tmp.write(uploaded_file.read())
+            tmp_path = tmp.name
+        return extract_text_from_pdf(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,10 @@ llama-api-client = "^0.1.0"
 pymupdf = "^1.25.5"
 openai = "^1.77.0"
 pypdf2 = "^3.0.1"
+deepseek = "^1.0.0"
 streamlit = "^1.46.0"
 streamlit-pyvista = "^0.0.18"
+nest-asyncio = "^1.6.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ llama-api-client = "^0.1.0"
 pymupdf = "^1.25.5"
 openai = "^1.77.0"
 pypdf2 = "^3.0.1"
+streamlit = "^1.46.0"
+streamlit-pyvista = "^0.0.18"
 
 
 [build-system]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,50 @@
+import streamlit as st
+from hutton_lm.pdf_parser import extract_text
+from hutton_lm.llm_interface import (
+    llm_consolidate_parsed_text,
+    llm_generate_dsl_summary,
+)
+from hutton_lm.model_builder import (
+    initialize_geomodel_with_tmp_files,
+    load_structural_definitions,
+    define_structural_groups,
+    compute_model_to_html,
+)
+from hutton_lm.data_loader import DEFAULT_STRUCTURE_FILE
+
+st.title("Geo-LM Interactive")
+
+uploaded = st.file_uploader("Upload geology PDF", type=["pdf"])
+
+if uploaded and st.button("Submit"):
+    with st.spinner("Extracting text"):
+        text = extract_text(uploaded)
+    if not text:
+        st.error("Failed to extract text from file")
+        st.stop()
+    st.success("Text extracted")
+    st.text_area("Excerpt", text[:2000])
+
+    with st.spinner("LLM consolidating"):
+        consolidated = llm_consolidate_parsed_text(text)
+    st.text_area("Consolidated", consolidated, height=200)
+
+    with st.spinner("Generating DSL"):
+        dsl = llm_generate_dsl_summary(consolidated)
+    st.text_area("Generated DSL", dsl, height=200)
+
+    with st.spinner("Running GemPy model"):
+        model = initialize_geomodel_with_tmp_files("StreamlitModel")
+        struct_defs = load_structural_definitions(DEFAULT_STRUCTURE_FILE)
+        if struct_defs:
+            define_structural_groups(model, struct_defs)
+            html_path = compute_model_to_html(model, "model.html")
+            with open(html_path) as f:
+                html = f.read()
+            st.components.v1.html(html, height=600)
+        else:
+            st.error("Failed to load structural definitions")
+
+st.markdown("## Launch")
+st.markdown("Run the app with:")
+st.code("streamlit run streamlit_app.py --server.address 0.0.0.0")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -48,3 +48,4 @@ if uploaded and st.button("Submit"):
 st.markdown("## Launch")
 st.markdown("Run the app with:")
 st.code("streamlit run streamlit_app.py --server.address 0.0.0.0")
+


### PR DESCRIPTION
## Summary
- create `streamlit_app.py` with upload, LLM, and GemPy modeling steps
- export GemPy plots to HTML for embedding
- add `extract_text` helper for Streamlit file uploads
- support HTML export with `compute_model_to_html`
- document Streamlit usage
- add streamlit dependencies

## Testing
- `python -m py_compile streamlit_app.py hutton_lm/pdf_parser.py hutton_lm/model_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870abaf342483248454ea428ca88a63