### PR TITLE
Add Streamlit interface and HTML plotting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ python run.py \
 
 This command will instruct the script to use the language model (`--input-mode llm`) with a default prompting strategy (`--prompt-type default`) and save the LLM's output (the generated geology DSL) to the `input-data/llm-generated` directory.
 
+### Streamlit interface
+
+An experimental Streamlit app provides a simple web interface for uploading a PDF and viewing the resulting 3‑D model. Make sure the `DEEPSEEK_API_KEY` environment variable is set, then run:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+After the upload completes the model will be displayed interactively in the browser. The app requires `pyvista` with its HTML export extras (`pip install "pyvista[jupyter]"`) for full functionality.
+
 ### Notes on Running
 
 This repo was originally tested on the following (open access?) paper:

--- a/hutton_lm/model_builder.py
+++ b/hutton_lm/model_builder.py
@@ -261,20 +261,40 @@ def define_structural_groups(geo_model: gp.data.GeoModel, structural_definitions
         pass  # Group didn't exist, that's fine
 
 
-def compute_and_plot_model(geo_model: gp.data.GeoModel):
-    """Computes the GemPy model and generates the 3D plot."""
+def compute_and_plot_model(
+    geo_model: gp.data.GeoModel, return_html: bool = False
+) -> str | None:
+    """Computes the GemPy model and generates the 3D plot.
+
+    If ``return_html`` is ``True``, the plot is not shown directly. Instead the
+    plotter's HTML representation is returned so it can be embedded in a web
+    interface such as Streamlit.
+    """
+
     print("Computing model...")
     gp.compute_model(gempy_model=geo_model)
 
     print("Generating 3D plot...")
-    gpv.plot_3d(
+    vista = gpv.plot_3d(
         model=geo_model,
         show_surfaces=True,
         show_data=True,
         image=False,
         show_topography=True,
         kwargs_plot_structured_grid={"opacity": 0.2},
+        show=not return_html,
     )
+
+    if return_html:
+        if hasattr(vista, "p"):
+            try:
+                html_io = vista.p.export_html(None)
+                return html_io.getvalue()
+            except Exception as e:
+                print(f"Failed to export plot HTML: {e}")
+                return None
+        return None
+
     print("Plot window should be open.")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ torch = "^2.7.0"
 pymupdf = "^1.25.5"
 pypdf2 = "^3.0.1"
 deepseek = "^1.0.0"
+streamlit = "^1.34.0"
 
 
 [build-system]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+import tempfile
+import streamlit as st
+
+from hutton_lm.pdf_parser import extract_text_from_pdf
+from hutton_lm.llm_interface import (
+    llm_consolidate_parsed_text,
+    llm_generate_dsl_summary,
+    run_llm_generation,
+)
+from hutton_lm.model_builder import (
+    initialize_geomodel_from_files,
+    initialize_geomodel_with_tmp_files,
+    load_structural_definitions,
+    define_structural_groups,
+    compute_and_plot_model,
+)
+
+st.title("Geo-LM Web Interface")
+
+uploaded_pdf = st.file_uploader("Upload a geology PDF", type=["pdf"])
+
+if uploaded_pdf is not None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(uploaded_pdf.read())
+        tmp_path = tmp.name
+
+    st.write("Extracting text from PDF...")
+    text = extract_text_from_pdf(tmp_path)
+
+    st.write("Consolidating text with LLM...")
+    consolidated = llm_consolidate_parsed_text(text)
+
+    st.write("Generating DSL with LLM...")
+    dsl_output = llm_generate_dsl_summary(consolidated)
+
+    llm_dir = tempfile.mkdtemp(prefix="llm_output_")
+    dsl_file = os.path.join(llm_dir, "geo_dsl.txt")
+    with open(dsl_file, "w", encoding="utf-8") as f:
+        f.write(dsl_output)
+
+    st.write("Running GemPy model generation...")
+    # Use run_llm_generation to produce csvs from DSL
+    gen_files = run_llm_generation("DSL", 0.7, llm_dir)
+    if not gen_files:
+        st.error("LLM generation failed")
+    else:
+        points_file, orientations_file, structure_file = gen_files
+        geo_model = initialize_geomodel_from_files(
+            "Streamlit_GeoModel", orientations_file, points_file
+        )
+        structural_defs = load_structural_definitions(structure_file)
+        if structural_defs is None:
+            st.error("Failed to load structural definitions")
+        else:
+            define_structural_groups(geo_model, structural_defs)
+            html = compute_and_plot_model(geo_model, return_html=True)
+            if html:
+                st.components.v1.html(html, height=600, width=800)
+            else:
+                st.error("Failed to generate plot HTML")
+
+st.write(
+    "Make sure the environment variable `DEEPSEEK_API_KEY` is set before running this app."
+)


### PR DESCRIPTION
## Summary
- allow GemPy plots to be exported to HTML in `compute_and_plot_model`
- add `streamlit_app.py` for uploading a PDF and showing the model
- document the Streamlit interface
- add `streamlit` dependency

## Testing
- `python -m compileall .`

------
https://chatgpt.com/codex/tasks/task_e_6870a962e83c832488471e3b7a1fb480